### PR TITLE
SREFTP-6278: Add Faraday 2 compatibility and modernize Ruby support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby_version: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby_version: [ '3.1', '3.2', '3.3', '3.4', '4.0' ]
 
     name: Ruby ${{ matrix.ruby_version }}
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Ruby gem to interact with CloudFlare API v4
 ## Build Status
 
 [![Build Status](https://github.com/peertransfer/glare/actions/workflows/ruby.yml/badge.svg)](https://github.com/peertransfer/glare/actions)
-[![Code Climate](https://codeclimate.com/github/peertransfer/glare/badges/gpa.svg)](https://codeclimate.com/github/peertransfer/glare)
 [![Known Vulnerabilities](https://snyk.io/test/github/peertransfer/glare/badge.svg)](https://snyk.io/test/github/peertransfer/glare)
 
 ## Installation

--- a/glare.gemspec
+++ b/glare.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
 
-  spec.add_dependency 'faraday', '~> 1.0'
-  spec.add_dependency 'faraday_middleware', '>= 1.0.0'
+  spec.add_dependency 'faraday', '>= 1.0', '< 3'
   spec.add_dependency 'public_suffix', '>= 3.0.2'
 
   spec.required_ruby_version = '>= 2.7.0'

--- a/glare.gemspec
+++ b/glare.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.9'
   spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'rspec', '~> 3.7'
 
   spec.add_dependency 'faraday', '>= 1.0', '< 3'

--- a/glare.gemspec
+++ b/glare.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 1.0', '< 3'
   spec.add_dependency 'public_suffix', '>= 3.0.2'
 
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1.0'
 end

--- a/lib/glare/client.rb
+++ b/lib/glare/client.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
+if Faraday::VERSION.to_i < 2
+  require 'faraday_middleware'
+end
 require 'logger'
 require 'glare/api_response'
 

--- a/lib/glare/version.rb
+++ b/lib/glare/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Glare
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
## Summary

- Broaden Faraday dependency to support both v1 and v2 (`>= 1.0, < 3`)
- Remove `faraday_middleware` as a hard runtime dependency; only require it on Faraday 1.x where it is needed (Faraday 2 includes JSON middleware built-in)
- Drop Ruby < 3.1 support; add Ruby 3.3, 3.4, and 4.0 to CI matrix
- Add `ostruct` dev dependency for Ruby 4.0 compatibility (removed from default gems)
- Remove Code Climate badge from README
- Bump version to 1.4.0

## Test plan

- [x] CI passes on Ruby 3.1, 3.2, 3.3, 3.4, 4.0
- [x] Unit tests pass with Faraday 2